### PR TITLE
Handle missing hemoglobin genes

### DIFF
--- a/R/plot_MappingErrorQC.R
+++ b/R/plot_MappingErrorQC.R
@@ -24,7 +24,7 @@ plot_MappingErrorQC <- function(query, mapQC_values = 'mapping_error_score', map
   }
 
   # Get Percentage Hemoglobin genes, this is to show that low quality cells mis-mapping to orthochromatic erythroblasts do not actually have Hb expression
-  query <- Seurat::PercentageFeatureSet(query, features = c('HBB', 'HBA1', 'HBA2', 'HBD', 'HBM'), assay = 'RNA', col.name = 'pct_Hb')
+  query <- Seurat::PercentageFeatureSet(query, features = base::intersect(c('HBB', 'HBA1', 'HBA2', 'HBD', 'HBM'), rownames(query@assays$RNA@counts)), assay = 'RNA', col.name = 'pct_Hb')
 
   # Plot Mapping error histogram to identify cutoff at tail of distribution
   p1 <- query@meta.data %>%


### PR DESCRIPTION
Hi.

While running one of the vignettes I got an error due to one of the hemoglobin genes (HBM) not being present in my seurat object. Probably this is due to the `min.cells` cut-off when first running the `CreateSeuratObject` function.

I imagine this might be a common occurrence, so I'm sharing my simplistic fix for it. 

Cheers!