### PR TITLE
Fix issue with 1xn dummy count matrix not working with CreateSeuratObject

### DIFF
--- a/R/create_ReferenceObject.R
+++ b/R/create_ReferenceObject.R
@@ -11,7 +11,7 @@
 #'
 create_ReferenceObject = function(ref_obj){
     ReferenceSeuratObj <- Seurat::CreateSeuratObject(mat.or.vec(nr = 2, nc = length(ref_obj$meta_data$Cell)) %>% 
-                             `colnames<-`(ref_obj$meta_data$Cell),
+                             `colnames<-`(ref_obj$meta_data$Cell) %>% `rownames<-`(c('var1','var2')),
                              meta.data = ref_obj$meta_data %>%
                               tibble::column_to_rownames('Cell'),
                              assay='RNA')

--- a/R/create_ReferenceObject.R
+++ b/R/create_ReferenceObject.R
@@ -10,10 +10,11 @@
 #' @export
 #'
 create_ReferenceObject = function(ref_obj){
-  ReferenceSeuratObj <- Seurat::CreateSeuratObject(data.frame(Cell = ref_obj$meta_data$Cell, placeholder = 0) %>% tibble::column_to_rownames('Cell') %>% data.matrix() %>% t(),
-                                                   meta.data = ref_obj$meta_data %>% tibble::column_to_rownames('Cell'),
-                                                   assay='RNA')
-
+    ReferenceSeuratObj <- Seurat::CreateSeuratObject(mat.or.vec(nr = 2, nc = length(ref_obj$meta_data$Cell)) %>% 
+                             `colnames<-`(ref_obj$meta_data$Cell),
+                             meta.data = ref_obj$meta_data %>%
+                              tibble::column_to_rownames('Cell'),
+                             assay='RNA')
   refUMAP <- data.frame(ref_obj$umap$embedding) %>% dplyr::rename(umap_1 = X1, umap_2 = X2) %>% data.matrix()
   rownames(refUMAP) <- ref_obj$meta_data$Cell
   ReferenceSeuratObj@reductions[['umap']] <- Seurat::CreateDimReducObject(refUMAP, key='umap_', assay='RNA')


### PR DESCRIPTION
With Seurat 5.0 at least, a single-row count matrix does not work for CreateSeuratObject(). Also simplified the creation of the matrix to avoid having to create it and then transpose. The matrix is changed to a sparse matrix by Seurat, so adding a row doesn't affect the memory profile much since it's all 0s. Tested with Seurat 5.0 in R 4.3.2