### PR TITLE
updated code to make it Seurat v5 compatible

### DIFF
--- a/R/map_Query.R
+++ b/R/map_Query.R
@@ -107,11 +107,11 @@ map_Query <- function (exp_query, metadata_query, ref_obj, vars = NULL, verbose 
   v<-packageVersion('Seurat')
   if(v<5)
     {
-      que <- SetAssayData(object = que, assay = 'RNA', layer = "data", new.data = exp_query)
-      que <- SetAssayData(object = que, assay = 'RNA', layer = "scale.data", new.data = exp_query_scaled_sync)
+      que <- SetAssayData(object = que, assay = 'RNA', slot = "data", new.data = exp_query)
+      que <- SetAssayData(object = que, assay = 'RNA', slot = "scale.data", new.data = exp_query_scaled_sync)
     }else{
-          que <- SetAssayData(object = que, assay = 'RNA', slot = "data", new.data = exp_query)
-          que <- SetAssayData(object = que, assay = 'RNA', slot = "scale.data", new.data = exp_query_scaled_sync)
+          que <- SetAssayData(object = que, assay = 'RNA', layer = "data", new.data = exp_query)
+          que <- SetAssayData(object = que, assay = 'RNA', layer = "scale.data", new.data = exp_query_scaled_sync)
     }
   que[['pca_projected']] <- Seurat::CreateDimReducObject(
     embeddings = t(Z_pca_query),

--- a/R/map_Query.R
+++ b/R/map_Query.R
@@ -104,8 +104,15 @@ map_Query <- function (exp_query, metadata_query, ref_obj, vars = NULL, verbose 
     message("All done!")
 
   # Return Seurat Object
-  que <- SetAssayData(object = que, assay = 'RNA', slot = "data", new.data = exp_query)
-  que <- SetAssayData(object = que, assay = 'RNA', slot = "scale.data", new.data = exp_query_scaled_sync)
+  v<-packageVersion('Seurat')
+  if(v<5)
+    {
+      que <- SetAssayData(object = que, assay = 'RNA', layer = "data", new.data = exp_query)
+      que <- SetAssayData(object = que, assay = 'RNA', layer = "scale.data", new.data = exp_query_scaled_sync)
+    }else{
+          que <- SetAssayData(object = que, assay = 'RNA', slot = "data", new.data = exp_query)
+          que <- SetAssayData(object = que, assay = 'RNA', slot = "scale.data", new.data = exp_query_scaled_sync)
+    }
   que[['pca_projected']] <- Seurat::CreateDimReducObject(
     embeddings = t(Z_pca_query),
     loadings = ref_obj$loadings,


### PR DESCRIPTION
mapQuery() was updated to allow use of both v3 and v5 for Seurat [for SetAssayData() in mapQuery.R] 